### PR TITLE
Multiple childViews with the same name

### DIFF
--- a/lib/nested_view.js
+++ b/lib/nested_view.js
@@ -130,12 +130,25 @@
       });
     },
 
-    registerChildView: function(childView,  name) {
-      this.childViews[name || childView.name] = childView;
+    registerChildView: function(childView,  key) {
+      this.childViews[key || childView.cid] = childView;
     },
 
-    getChildView: function(viewName) {
-      return this.childViews[viewName];
+    getChildView: function(name) {
+      if (this.childViews[name] !== undefined) {
+        return this.childViews[name];
+      }
+      
+      var childrenWithName = _.select(this.childViews, function(childView) {
+        return (childView.name === name);
+      });
+
+      if (childrenWithName.length > 1) {
+        return childrenWithName;
+      }
+      else {
+        return childrenWithName[0];
+      }
     }
   });
 

--- a/test/browser.js
+++ b/test/browser.js
@@ -38,7 +38,7 @@
     className: 'listing',
     postRender: function(){
       var _this = this;
-      this.childViews['user_view'].on('clicked', function(e){
+      this.getChildView('user_view').on('clicked', function(e){
         _this.trigger('child_clicked', e);
       });
     }
@@ -73,7 +73,7 @@
 
         listingView.on('child_clicked', function(e){
           assert(true);
-          assert.equal(e.currentTarget, listingView.childViews['user_view'].el);
+          assert.equal(e.currentTarget, listingView.getChildView('user_view').el);
           done();
           $('#container').html('');
         });


### PR DESCRIPTION
The `childViews` hash is indexed by a child view's name, so if you try to specify multiple child views with the same type but different contexts (for example, to compare two things side-by-side), only one of those children will attach properly, and no errors will be thrown.
